### PR TITLE
[新增功能] 讓其他擴展使用此擴展作為與 Aria2 的中介軟體

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,19 @@ Aria2 for chrome 是一款为Chrome定制的下载任务管理扩展，能够自
 并且可以设置多大的文件使用导出下载,小文件使用Chrome自带的下载功能,拦截下载默认使用第一个RPC地址.
 
 开启右键菜单之后任意链接都可以右键导出到Aria2进行下载.
+## Integration
+允許其他擴展使用這個擴展作為與 Aria2 的中介軟體來下載檔案。
 
+Allow other extensions use this extension as middleware to download file with Aria2.
+```js
+const downloadItem = {
+    "url": "https://sample.com/image.jpg",
+    "filename": "image_from_sample.jpg",
+    "referer": "https://sample.com"
+}
+
+chrome.runtime.sendMessage(`Aria2 for Chrome extension ID`, downloadItem)
+```
 
 # Install
 

--- a/background.js
+++ b/background.js
@@ -1,5 +1,6 @@
 const defaultRPC = '[{"name":"ARIA2 RPC","url":"http://localhost:6800/jsonrpc"}]';
 var CurrentTabUrl = "";
+const fetchRpcList = () => JSON.parse(localStorage.getItem("rpc_list") || defaultRPC)
 var HttpSendRead = function(info) {
     Promise.prototype.done = Promise.prototype.then;
     Promise.prototype.fail = Promise.prototype.catch;
@@ -490,3 +491,18 @@ if (integration == "true") {
 } else if (integration == "false" || integration == null) {
     disableCapture();
 }
+
+// receive request from other extension
+/**
+ * @typedef downloadItem
+ * @type {Object}
+ * @property {String} url
+ * @property {String} filename
+ * @property {String} referer
+ */
+chrome.runtime.onMessageExternal.addListener(
+    function (downloadItem) {
+        const rpc_list = fetchRpcList()
+        aria2Send(downloadItem.url, rpc_list[0]['url'], downloadItem)
+    }
+);

--- a/manifest.json
+++ b/manifest.json
@@ -6,16 +6,16 @@
    "permissions": [ "cookies", "tabs", "notifications", "activeTab", "contextMenus", "downloads","<all_urls>","storage"],
    "version": "1.2.9",
    "minimum_chrome_version": "50.0.0",
-   
+
    "background": {
       "persistent": false,
       "scripts": [ "background.js" ]
    },
-   
+
    "browser_action": {
       "default_icon": "images/logo64.png"
    },
-   
+
    "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self'",
    "default_locale": "en",
    "description": "__MSG_description__",
@@ -31,5 +31,10 @@
             },
             "description": "__MSG_toggleCapture__"
           }
+   },
+   "externally_connectable": {
+      "ids": [
+         "*"
+      ]
    }
 }


### PR DESCRIPTION
Reference issue #29 
以我的[擴展](https://github.com/EltonChou/TwitterMediaHarvest/commit/94b8287f866779ef878c5c04cc82051f08e29df9)為例，這樣就能讓其他擴展能夠透過此擴展來驅動 Aria2 下載檔案
- 新增外部監聽於 EltonChou/Aria2-for-chrome@3bd9564161e6a0f21cff650292fe3d5425d330db
- 新增說明於 EltonChou/Aria2-for-Chrome@3eb1360583e2dff688132767b8fed0169e9e0a5b