### PR TITLE
Chrome扩展联动时接收aria2原生参数

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,11 @@ Allow other extensions use this extension as middleware to download file with Ar
 const downloadItem = {
     "url": "https://sample.com/image.jpg",
     "filename": "image_from_sample.jpg",
-    "referrer": "https://sample.com"
+    "referrer": "https://sample.com",
+    "options": { // 此处为aria2 的原生参数
+        "split": "10",
+        "...": "..."
+    }
 }
 
 chrome.runtime.sendMessage(`Aria2 for Chrome extension ID`, downloadItem)

--- a/background.js
+++ b/background.js
@@ -78,19 +78,8 @@ function parse_url(url) {
 }
 
 function aria2Send(link, rpcUrl, downloadItem) {
-    var filename = null;
-    var referrer = null;
-    var cookiesLink = null;
-    if (downloadItem != null) {
-        filename = downloadItem.filename;
-        referrer = downloadItem.referrer;
-        cookiesLink = link;
-    } else {
-        cookiesLink = link;
-    }
-
     chrome.cookies.getAll({
-        "url": cookiesLink
+        "url": link
     }, function(cookies) {
         var format_cookies = [];
         for (var i in cookies) {
@@ -104,8 +93,8 @@ function aria2Send(link, rpcUrl, downloadItem) {
 
         var options = {
                 "header": header,
-                "referer": referrer,
-                "out": filename
+                "referer": downloadItem.referrer,
+                "out": downloadItem.filename
         };
         if(downloadItem.hasOwnProperty('options')){
             options = Object.assign(options, downloadItem.options);

--- a/background.js
+++ b/background.js
@@ -102,15 +102,20 @@ function aria2Send(link, rpcUrl, downloadItem) {
         header.push("User-Agent: " + navigator.userAgent);
         header.push("Connection: keep-alive");
 
+        var options = {
+                "header": header,
+                "referer": referrer,
+                "out": filename
+        };
+        if(downloadItem.hasOwnProperty('options')){
+            options = Object.assign(options, downloadItem.options);
+        }
+
         var rpc_data = {
             "jsonrpc": "2.0",
             "method": "aria2.addUri",
             "id": new Date().getTime(),
-            "params": [[link], {
-                "header": header,
-                "referer": referrer,
-                "out": filename
-            }]
+            "params": [[link], options]
         };
         var result = parse_url(rpcUrl);
         var auth = result[1];


### PR DESCRIPTION
使用gdindex搭建的站点下载时可能需要用户名及密码才能正常下载，可以在调用时通过aria2的原生参数传入，更可以自定义下载目录，线程数量等。