### PR TITLE
fix: update Chrome Web Store URLs to new format

### DIFF
--- a/README.cn.md
+++ b/README.cn.md
@@ -66,7 +66,7 @@ chrome.runtime.sendMessage(`Aria2-Explorer extension ID`, downloadItem)
 
 ## 📥 安装地址
 
-[![Chrome Web Store](https://developer.chrome.com/static/docs/webstore/branding/image/UV4C4ybeBTsZt43U4xis.png)](https://chrome.google.com/webstore/detail/mpkodccbngfoacfalldjimigbofkhgjn "Aria2 Explorer")
+[![Chrome Web Store](https://developer.chrome.com/static/docs/webstore/branding/image/UV4C4ybeBTsZt43U4xis.png)](https://chromewebstore.google.com/detail/mpkodccbngfoacfalldjimigbofkhgjn "Aria2 Explorer")
 [<img src="https://get.microsoft.com/images/zh-cn%20light.svg" height=58 >](https://microsoftedge.microsoft.com/addons/detail/jjfgljkjddpcpfapejfkelkbjbehagbh "Aria2 Explorer")
 
 ## 💡 常见问题

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ chrome.runtime.sendMessage(`Aria2-Explorer extension ID`, downloadItem)
 
 ## 📥 Installation
 
-[![Chrome Web Store](https://developer.chrome.com/static/docs/webstore/branding/image/UV4C4ybeBTsZt43U4xis.png)](https://chrome.google.com/webstore/detail/mpkodccbngfoacfalldjimigbofkhgjn "Aria2 Explorer")
+[![Chrome Web Store](https://developer.chrome.com/static/docs/webstore/branding/image/UV4C4ybeBTsZt43U4xis.png)](https://chromewebstore.google.com/detail/mpkodccbngfoacfalldjimigbofkhgjn "Aria2 Explorer")
 [<img src="https://get.microsoft.com/images/en-us%20light.svg" height=58 >](https://microsoftedge.microsoft.com/addons/detail/jjfgljkjddpcpfapejfkelkbjbehagbh "Aria2 Explorer")
 
 ## 💡 Tips & FAQs

--- a/js/utils.js
+++ b/js/utils.js
@@ -255,7 +255,7 @@ class Utils {
         if (/Edg/.test(navigator.userAgent))
             return "https://microsoftedge.microsoft.com/addons/detail/" + id;
         else
-            return "https://chrome.google.com/webstore/detail/" + id;
+            return "https://chromewebstore.google.com/detail/" + id;
     }
 
     /**


### PR DESCRIPTION
Updates chrome.google.com/webstore to chromewebstore.google.com in:
- README.md
- README.cn.md
- js/utils.js

---
*Contributed by [theluckystrike](https://github.com/theluckystrike) | [Zovo](https://zovo.one) — Chrome Extension Studio*